### PR TITLE
add allInOne option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ puml-gen InputPath [OutputPath] [-dir] [-public | -ignore IgnoreAccessibilities]
 - -excludePaths: (Optional) Specify the exclude file and directory.   
   Specifies a relative path from the "InputPath", with a comma separated list.
 - -createAssociation: (Optional) Create object associations from references of fields and properites.
+- -allInOne: (Optional) Only if -dir is set: copy the output of all diagrams to file include.puml (this allows a PlanUMLServer to render it).
 
 
 examples
@@ -39,7 +40,7 @@ puml-gen C:\Source\App1\ClassA.cs -public
 ```
 
 ```bat
-puml-gen C:\Source\App1 C:\PlantUml\App1 -dir -ignore Private,Protected -createAssociation
+puml-gen C:\Source\App1 C:\PlantUml\App1 -dir -ignore Private,Protected -createAssociation -allInOne
 ```
 
 ```bat

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -23,7 +23,8 @@ namespace PlantUmlClassDiagramGenerator
             ["-public"] = OptionType.Switch,
             ["-ignore"] = OptionType.Value,
             ["-excludePaths"] = OptionType.Value,
-            ["-createAssociation"] = OptionType.Switch
+            ["-createAssociation"] = OptionType.Switch,
+            ["-allInOne"] = OptionType.Switch
         };
 
         static int Main(string[] args)
@@ -135,8 +136,15 @@ namespace PlantUmlClassDiagramGenerator
             }
 
             var files = Directory.EnumerateFiles(inputRoot, "*.cs", SearchOption.AllDirectories);
+
+
+
+
             var includeRefs = new StringBuilder();
             includeRefs.AppendLine("@startuml");
+
+
+
             var error = false;
             foreach (var inputFile in files)
             {
@@ -169,7 +177,18 @@ namespace PlantUmlClassDiagramGenerator
                         }
                     }
 
-                    includeRefs.AppendLine("!include " + outputFile.Replace(outputRoot, @".\"));
+                    if (parameters.ContainsKey("-allInOne"))
+                    {
+                        var lines = File.ReadAllLines(outputFile);
+                        foreach (string line in lines.Skip(1).SkipLast(1))
+                        {
+                            includeRefs.AppendLine(line);
+                        }
+                    }
+                    else
+                    {
+                        includeRefs.AppendLine("!include " + outputFile.Replace(outputRoot, @".\"));
+                    }
                 }
                 catch (Exception e)
                 {
@@ -179,6 +198,7 @@ namespace PlantUmlClassDiagramGenerator
             }
             includeRefs.AppendLine("@enduml");
             File.WriteAllText(CombinePath(outputRoot, "include.puml"), includeRefs.ToString());
+
             if (error)
             {
                 Console.WriteLine("There were files that could not be processed.");


### PR DESCRIPTION
Adds the option to generate a full copy of all the sub-diagrams and save it in the file `include.puml` instead of adding only `!include` lines to it. This allows PlanUMLServers to render the whole diagram, since all the information is included in a single file. 

I have modified the Readme.md file to explain the changes as well.