### PR TITLE
Fixes for outputPath and allInOne

### DIFF
--- a/tools/csharp-to-plantuml/package.json
+++ b/tools/csharp-to-plantuml/package.json
@@ -67,6 +67,12 @@
 					"scope": "resource",
 					"default": true,
 					"description": "Create object associations from field and property references."
+				},
+				"csharp2plantuml.allInOne": {
+					"type": "boolean",
+					"scope": "resource",
+					"default": false,
+					"description": "Copy the output of all diagrams to file include.puml (this allows a PlanUMLServer to render it)."
 				}
 			}
 		}

--- a/tools/csharp-to-plantuml/src/extension.ts
+++ b/tools/csharp-to-plantuml/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		var command = `dotnet "${tool}" "${input}"`;
 		if (outputPath !== "") {
-			command += ` "${pathJoin(input, outputPath)}"`;
+			command += ` "${pathJoin(wsroot, outputPath)}"`;
 		}
 		command += " -dir";
 		if (publicOnly) {
@@ -47,10 +47,10 @@ export function activate(context: vscode.ExtensionContext) {
 		} else if (ignoreAccessibility !== "") {
 			command += ` -ignore "${ignoreAccessibility}"`;
 		}
-		if(excludePath !==""){
+		if (excludePath !== "") {
 			command += ` "${pathJoin(input, excludePath)}"`;
 		}
-		if(createAssociation){
+		if (createAssociation) {
 			command += " -createAssociation";
 		}
 

--- a/tools/csharp-to-plantuml/src/extension.ts
+++ b/tools/csharp-to-plantuml/src/extension.ts
@@ -35,6 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
 		const ignoreAccessibility = conf.get('csharp2plantuml.ignoreAccessibility') as string;
 		const excludePath = conf.get('csharp2plantuml.excludePath') as string;
 		const createAssociation = conf.get('csharp2plantuml.createAssociation') as boolean;
+		const allInOne = conf.get('csharp2plantuml.allInOne') as boolean;
 		const input = pathJoin(wsroot, inputPath);
 
 		var command = `dotnet "${tool}" "${input}"`;
@@ -52,6 +53,9 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 		if (createAssociation) {
 			command += " -createAssociation";
+		}
+		if (allInOne) {
+			command += " -allInOne";
 		}
 
 		outputchannel.appendLine("[exec] " + command);


### PR DESCRIPTION
- Append output path to workspace root as intended.
- Add "allInOne" option and bind with correct config.
- Add allInOne to `package.json` (and fix typo).