### PR TITLE
Use double quotes for the @ prefix

### DIFF
--- a/src/PlantUmlClassDiagramGenerator.Library/TypeNameText.cs
+++ b/src/PlantUmlClassDiagramGenerator.Library/TypeNameText.cs
@@ -19,6 +19,10 @@ namespace PlantUmlClassDiagramGenerator.Library
                 identifier = $"\"{identifier}`{count}\"";
                 typeArgs = "<" + string.Join(",", genericName.TypeArgumentList.Arguments) + ">";
             }
+            else
+            {
+                identifier = $"\"{identifier}\"";
+            }
             return new TypeNameText
             {
                 Identifier = identifier,
@@ -59,6 +63,10 @@ namespace PlantUmlClassDiagramGenerator.Library
                 var count = typeDeclaration.TypeParameterList.Parameters.Count;
                 identifier = $"\"{identifier}`{count}\"";
                 typeArgs = "<" + string.Join(",", typeDeclaration.TypeParameterList.Parameters) + ">";
+            }
+            else
+            {
+                identifier = $"\"{identifier}\"";
             }
             return new TypeNameText
             {

--- a/src/PlantUmlClassDiagramGenerator.Library/TypeNameText.cs
+++ b/src/PlantUmlClassDiagramGenerator.Library/TypeNameText.cs
@@ -19,7 +19,7 @@ namespace PlantUmlClassDiagramGenerator.Library
                 identifier = $"\"{identifier}`{count}\"";
                 typeArgs = "<" + string.Join(",", genericName.TypeArgumentList.Arguments) + ">";
             }
-            else
+            else if (identifier.StartsWith("@"))
             {
                 identifier = $"\"{identifier}\"";
             }
@@ -64,7 +64,7 @@ namespace PlantUmlClassDiagramGenerator.Library
                 identifier = $"\"{identifier}`{count}\"";
                 typeArgs = "<" + string.Join(",", typeDeclaration.TypeParameterList.Parameters) + ">";
             }
-            else
+            else if (identifier.StartsWith("@"))
             {
                 identifier = $"\"{identifier}\"";
             }


### PR DESCRIPTION
fix #32

**input.cs**
```cs
@startuml
class @ClassA{
    public @IList<@string> @Strings{get;} = new @List<@string>();
        public @Type1 @Prop1{get;set;}
            public @Type2 @field1;
}

class @Type1 {
    public @int @value1{get;set;}
}

class @Type2{
    public @string @string1{get;set;}
        public @ExternalType @Prop2 {get;set;}
}
@enduml
```

puml generated after fix
```puml
@startuml
class "@ClassA" {
}
class "@Type1" {
}
class "@Type2" {
}
class "@IList`1"<T> {
}
"@ClassA" o-> "@Strings<@string>" "@IList`1"
"@ClassA" --> "@Prop1" "@Type1"
"@ClassA" --> "@field1" "@Type2"
"@Type1" --> "@value1" "@int"
"@Type2" --> "@string1" "@string"
"@Type2" --> "@Prop2" "@ExternalType"
@enduml
```

![image](https://user-images.githubusercontent.com/1295639/97720424-9d257500-1b0b-11eb-8b30-c9c08a6c5552.png)

puml generated before fix
```puml
$ puml-gen .\input.cs -createAssociation
$ cat input.cs
@startuml
class @ClassA {
}
class @Type1 {
}
class @Type2 {
}
class "@IList`1"<T> {
}
@ClassA o-> "@Strings<@string>" "@IList`1"
@ClassA --> "@Prop1" @Type1
@ClassA --> "@field1" @Type2
@Type1 --> "@value1" @int
@Type2 --> "@string1" @string
@Type2 --> "@Prop2" @ExternalType
@enduml
```
