### PR TITLE
Escaping curly brackets in a string variable

### DIFF
--- a/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
@@ -135,6 +135,27 @@ namespace PlantUmlClassDiagramGeneratorTest
             Assert.AreEqual(expected, actual);
         }
 
+        [TestMethod]
+        public void GenerateTest_CurlyBrackets()
+        {
+            var code = File.ReadAllText("testData\\CurlyBrackets.cs");
+            var tree = CSharpSyntaxTree.ParseText(code);
+            var root = tree.GetRoot();
+
+            var output = new StringBuilder();
+            using (var writer = new StringWriter(output))
+            {
+                var gen = new ClassDiagramGenerator(writer, "    ", Accessibilities.Private | Accessibilities.Internal
+                                                                                            | Accessibilities.Protected | Accessibilities.ProtectedInternal, true);
+                gen.Generate(root);
+            }
+
+            var expected = ConvertNewLineCode(File.ReadAllText(@"uml\CurlyBrackets.puml"), Environment.NewLine);
+            var actual = output.ToString();
+            Console.Write(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
         private string ConvertNewLineCode(string text, string newline)
         {
             var reg = new System.Text.RegularExpressions.Regex("\r\n|\r|\n");

--- a/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
+++ b/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
@@ -19,6 +19,7 @@
     <Compile Remove="testData\AtPrefixType.cs" />
     <Compile Remove="testData\GenericsType.cs" />
     <Compile Remove="testData\InputClasses.cs" />
+    <Compile Remove="testData\CurlyBrackets.cs" />
     <Compile Remove="testData\NullableType.cs" />
   </ItemGroup>
 
@@ -30,6 +31,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="testData\InputClasses.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="testData\CurlyBrackets.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="testData\NullableType.cs">
@@ -45,6 +49,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="uml\AtPrefixType.puml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="uml\CurlyBrackets.puml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="uml\public.puml">

--- a/test/PlantUmlClassDiagramGeneratorTest/testData/CurlyBrackets.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/testData/CurlyBrackets.cs
@@ -1,0 +1,22 @@
+namespace PlantUmlClassDiagramGeneratorTest
+{
+    public class CurlyBrackets
+    {
+        public string openingBracket = @"
+{
+";
+        public string openingBrackets = @"
+{{
+";
+        public string closingBracket = @"
+}
+";
+        public string closingBrackets = @"
+}}
+";
+        public string bothBrackets = @"
+{{
+}}
+";
+    }
+}

--- a/test/PlantUmlClassDiagramGeneratorTest/uml/CurlyBrackets.puml
+++ b/test/PlantUmlClassDiagramGeneratorTest/uml/CurlyBrackets.puml
@@ -1,0 +1,20 @@
+@startuml
+class CurlyBrackets {
+    + openingBracket : string = @"
+{
+"
+    + openingBrackets : string = @"
+&#123;{
+"
+    + closingBracket : string = @"
+&#125;
+"
+    + closingBrackets : string = @"
+}}
+"
+    + bothBrackets : string = @"
+&#123;{
+}}
+"
+}
+@enduml


### PR DESCRIPTION
fix #34

Converts double opening brackets and single closing brackets (`{{` and `}`) to numeric character references.
Single open curly bracket and double closed brackets (`{` and `}}`) are not a problem. But the conversion errors are plantuml-dependent, so I don't know if I can avoid all of them.

