### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ puml-gen C:\Source\App1 C:\PlantUml\App1 -dir -excludePaths bin,obj,Properties
 
 |C#               | PlantUML           |
 |:----------------|-------------------:|
-| `abstrct`       | `abstract`         |
+| `abstract`       | `abstract`         |
 | `static`        | `<<static>>`       |
 | `partial`       | `<<partial>>`      |
 | `sealed`        | `<<sealed>>`       |


### PR DESCRIPTION
I have never seen `abstrct` in a C# code base therefore I assumed it was a typo