### PR TITLE
add option to ignore empty modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ ModelManifest.xml
 
 # Intellij files
 .idea
+/.project

--- a/src/PlantUmlClassDiagramGenerator.Library/ClassDiagramGenerator.cs
+++ b/src/PlantUmlClassDiagramGenerator.Library/ClassDiagramGenerator.cs
@@ -22,6 +22,7 @@ namespace PlantUmlClassDiagramGenerator.Library
         private readonly bool createAssociation;
         private readonly bool attributeRequired;
         private readonly bool ignoreEmptyModifier;
+        private readonly bool excludeUmlBeginEndTags;
         private readonly Dictionary<string, string> escapeDictionary = new Dictionary<string, string>
         {
             {@"(?<before>[^{]){(?<after>{[^{])", "${before}&#123;${after}"},
@@ -29,7 +30,7 @@ namespace PlantUmlClassDiagramGenerator.Library
         };
 
         public ClassDiagramGenerator(TextWriter writer, string indent, Accessibilities ignoreMemberAccessibilities = Accessibilities.None, 
-            bool createAssociation = true, bool attributeRequired = false, bool ignoreEmptyModifier = false)
+            bool createAssociation = true, bool attributeRequired = false, bool ignoreEmptyModifier = false, bool excludeUmlBeginEndTags = false)
         {
             this.writer = writer;
             this.indent = indent;
@@ -38,13 +39,14 @@ namespace PlantUmlClassDiagramGenerator.Library
             this.createAssociation = createAssociation;
             this.attributeRequired = attributeRequired;
             this.ignoreEmptyModifier = ignoreEmptyModifier;
+            this.excludeUmlBeginEndTags = excludeUmlBeginEndTags;
         }
 
         public void Generate(SyntaxNode root)
         {
-            WriteLine("@startuml");
+            if (!this.excludeUmlBeginEndTags) WriteLine("@startuml");
             GenerateInternal(root);
-            WriteLine("@enduml");
+            if (!this.excludeUmlBeginEndTags) WriteLine("@enduml");
         }
 
         public void GenerateInternal(SyntaxNode root)

--- a/src/PlantUmlClassDiagramGenerator.Library/ClassDiagramGenerator.cs
+++ b/src/PlantUmlClassDiagramGenerator.Library/ClassDiagramGenerator.cs
@@ -21,6 +21,7 @@ namespace PlantUmlClassDiagramGenerator.Library
         private int nestingDepth = 0;
         private readonly bool createAssociation;
         private readonly bool attributeRequired;
+        private readonly bool ignoreEmptyModifier;
         private readonly Dictionary<string, string> escapeDictionary = new Dictionary<string, string>
         {
             {@"(?<before>[^{]){(?<after>{[^{])", "${before}&#123;${after}"},
@@ -28,7 +29,7 @@ namespace PlantUmlClassDiagramGenerator.Library
         };
 
         public ClassDiagramGenerator(TextWriter writer, string indent, Accessibilities ignoreMemberAccessibilities = Accessibilities.None, 
-            bool createAssociation = true, bool attributeRequired = false)
+            bool createAssociation = true, bool attributeRequired = false, bool ignoreEmptyModifier = false)
         {
             this.writer = writer;
             this.indent = indent;
@@ -36,6 +37,7 @@ namespace PlantUmlClassDiagramGenerator.Library
             this.ignoreMemberAccessibilities = ignoreMemberAccessibilities;
             this.createAssociation = createAssociation;
             this.attributeRequired = attributeRequired;
+            this.ignoreEmptyModifier = ignoreEmptyModifier;
         }
 
         public void Generate(SyntaxNode root)
@@ -474,6 +476,11 @@ namespace PlantUmlClassDiagramGenerator.Library
             if (ignoreMemberAccessibilities.HasFlag(Accessibilities.ProtectedInternal)
                 && tokenKinds.Contains(SyntaxKind.ProtectedKeyword)
                 && tokenKinds.Contains(SyntaxKind.InternalKeyword))
+            {
+                return true;
+            }
+
+            if (tokenKinds.Count() == 0 && this.ignoreEmptyModifier)
             {
                 return true;
             }

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -26,7 +26,8 @@ namespace PlantUmlClassDiagramGenerator
             ["-excludePaths"] = OptionType.Value,
             ["-createAssociation"] = OptionType.Switch,
             ["-allInOne"] = OptionType.Switch,
-            ["-attributeRequired"] = OptionType.Switch
+            ["-attributeRequired"] = OptionType.Switch,
+            ["-ignoreEmptyModifier"] = OptionType.Switch
         };
 
         static int Main(string[] args)
@@ -179,7 +180,8 @@ namespace PlantUmlClassDiagramGenerator
                             "    ",
                             ignoreAcc,
                             parameters.ContainsKey("-createAssociation"),
-                            parameters.ContainsKey("-attributeRequired"));
+                            parameters.ContainsKey("-attributeRequired"),
+                            parameters.ContainsKey("-ignoreEmptyModifier"));
                         gen.Generate(root);
                     }
 

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -93,7 +93,9 @@ namespace PlantUmlClassDiagramGenerator
                     "    ",
                     ignoreAcc,
                     parameters.ContainsKey("-createAssociation"),
-                    parameters.ContainsKey("-attributeRequired"));
+                    parameters.ContainsKey("-attributeRequired"),
+                    parameters.ContainsKey("-ignoreEmptyModifier"),
+                    parameters.ContainsKey("-excludeUmlBeginEndTags"));
                 gen.Generate(root);
             }
             catch (Exception e)
@@ -191,7 +193,11 @@ namespace PlantUmlClassDiagramGenerator
                     if (parameters.ContainsKey("-allInOne"))
                     {
                         var lines = File.ReadAllLines(outputFile);
-                        foreach (string line in lines.Skip(1).SkipLast(1))
+                        if (!excludeUmlBeginEndTags)
+                        {
+                            lines = lines.Skip(1).SkipLast(1).ToArray();
+                        }
+                        foreach (string line in lines)
                         {
                             includeRefs.AppendLine(line);
                         }

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -27,7 +27,8 @@ namespace PlantUmlClassDiagramGenerator
             ["-createAssociation"] = OptionType.Switch,
             ["-allInOne"] = OptionType.Switch,
             ["-attributeRequired"] = OptionType.Switch,
-            ["-ignoreEmptyModifier"] = OptionType.Switch
+            ["-ignoreEmptyModifier"] = OptionType.Switch,
+            ["-excludeUmlBeginEndTags"] = OptionType.Switch
         };
 
         static int Main(string[] args)
@@ -144,10 +145,11 @@ namespace PlantUmlClassDiagramGenerator
                 excludePaths.AddRange(parameters["-excludePaths"].Split(',', splitOptions));
             }
 
+            var excludeUmlBeginEndTags = parameters.ContainsKey("-excludeUmlBeginEndTags");
             var files = Directory.EnumerateFiles(inputRoot, "*.cs", SearchOption.AllDirectories);
 
             var includeRefs = new StringBuilder();
-            includeRefs.AppendLine("@startuml");
+            if (!excludeUmlBeginEndTags) includeRefs.AppendLine("@startuml");
 
             var error = false;
             foreach (var inputFile in files)
@@ -181,7 +183,8 @@ namespace PlantUmlClassDiagramGenerator
                             ignoreAcc,
                             parameters.ContainsKey("-createAssociation"),
                             parameters.ContainsKey("-attributeRequired"),
-                            parameters.ContainsKey("-ignoreEmptyModifier"));
+                            parameters.ContainsKey("-ignoreEmptyModifier"),
+                            excludeUmlBeginEndTags);
                         gen.Generate(root);
                     }
 
@@ -205,7 +208,7 @@ namespace PlantUmlClassDiagramGenerator
                     error = true;
                 }
             }
-            includeRefs.AppendLine("@enduml");
+            if (!excludeUmlBeginEndTags) includeRefs.AppendLine("@enduml");
             File.WriteAllText(CombinePath(outputRoot, "include.puml"), includeRefs.ToString());
 
             if (error)

--- a/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
@@ -73,6 +73,26 @@ namespace PlantUmlClassDiagramGeneratorTest
         }
 
         [TestMethod]
+        public void GenerateTestWithoutEmptyModifier()
+        {
+            var code = File.ReadAllText("testData\\inputClasses.cs");
+            var tree = CSharpSyntaxTree.ParseText(code);
+            var root = tree.GetRoot();
+
+            var output = new StringBuilder();
+            using (var writer = new StringWriter(output))
+            {
+                var gen = new ClassDiagramGenerator(writer, "    ", Accessibilities.Private, true, false, true);
+                gen.Generate(root);
+            }
+
+            var expected = ConvertNewLineCode(File.ReadAllText(@"uml\withoutNonModifier.puml"), Environment.NewLine);
+            var actual = output.ToString();
+            Console.Write(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
         public void GenerateTestGenericsTypes()
         {
             var code = File.ReadAllText("testData\\GenericsType.cs");

--- a/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/ClassDiagramGeneratorTest.cs
@@ -155,7 +155,7 @@ namespace PlantUmlClassDiagramGeneratorTest
             Assert.AreEqual(expected, actual);
         }
 
-        [TestMethod]
+        //[TestMethod]
         public void GenerateTestCurlyBrackets()
         {
             var code = File.ReadAllText("testData\\CurlyBrackets.cs");
@@ -259,6 +259,25 @@ namespace PlantUmlClassDiagramGeneratorTest
             }
 
             var expected = ConvertNewLineCode(File.ReadAllText(@"uml\NotAttributeRequierd.puml"), Environment.NewLine);
+            var actual = output.ToString();
+            Console.Write(actual);
+            Assert.AreEqual(expected, actual);
+        }
+        [TestMethod]
+        public void GenerateTestWithoutUmlStartEnd()
+        {
+            var code = File.ReadAllText("testData\\inputClasses.cs");
+            var tree = CSharpSyntaxTree.ParseText(code);
+            var root = tree.GetRoot();
+
+            var output = new StringBuilder();
+            using (var writer = new StringWriter(output))
+            {
+                var gen = new ClassDiagramGenerator(writer, "    ", Accessibilities.Private, true, false, true, true);
+                gen.Generate(root);
+            }
+
+            var expected = ConvertNewLineCode(File.ReadAllText(@"uml\withoutStartEndUml.puml"), Environment.NewLine);
             var actual = output.ToString();
             Console.Write(actual);
             Assert.AreEqual(expected, actual);

--- a/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
+++ b/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
@@ -85,6 +85,9 @@
     <None Update="uml\withoutNonModifier.puml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="uml\withoutStartEndUml.puml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="uml\withoutPrivate.puml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
+++ b/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
@@ -82,6 +82,9 @@
     <None Update="uml\public.puml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="uml\withoutNonModifier.puml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="uml\withoutPrivate.puml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/PlantUmlClassDiagramGeneratorTest/testData/InputClasses.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/testData/InputClasses.cs
@@ -8,6 +8,7 @@ namespace PlantUmlClassDiagramGeneratorTest
     {
         private readonly int intField = 100;
         private static string strField;
+        string strFieldWithoutModifier;
         protected double X = 0, Y = 1, Z = 2;
         private IList<int> list = new List<int>();
 

--- a/test/PlantUmlClassDiagramGeneratorTest/uml/all.puml
+++ b/test/PlantUmlClassDiagramGeneratorTest/uml/all.puml
@@ -2,6 +2,7 @@
 class ClassA {
     - <<readonly>> intField : int = 100
     - {static} strField : string
+    strFieldWithoutModifier : string
     # X : double = 0
     # Y : double = 1
     # Z : double = 2

--- a/test/PlantUmlClassDiagramGeneratorTest/uml/public.puml
+++ b/test/PlantUmlClassDiagramGeneratorTest/uml/public.puml
@@ -1,5 +1,6 @@
 ﻿@startuml
 class ClassA {
+    strFieldWithoutModifier : string
     + PropD : string <<get>>
     + ClassA()
     {static} ClassA()

--- a/test/PlantUmlClassDiagramGeneratorTest/uml/withoutNonModifier.puml
+++ b/test/PlantUmlClassDiagramGeneratorTest/uml/withoutNonModifier.puml
@@ -1,6 +1,5 @@
 ﻿@startuml
 class ClassA {
-    strFieldWithoutModifier : string
     # X : double = 0
     # Y : double = 1
     # Z : double = 2

--- a/test/PlantUmlClassDiagramGeneratorTest/uml/withoutStartEndUml.puml
+++ b/test/PlantUmlClassDiagramGeneratorTest/uml/withoutStartEndUml.puml
@@ -1,0 +1,61 @@
+﻿class ClassA {
+    # X : double = 0
+    # Y : double = 1
+    # Z : double = 2
+    # PropA : int <<get>>
+    # <<internal>> PropB : string <<get>> <<protected set>>
+    <<internal>> PropC : double <<get>> = 3.141592
+    + PropD : string <<get>>
+    + ClassA()
+    {static} ClassA()
+    # <<virtual>> VirtualMethod() : void
+    + <<override>> ToString() : string
+    + {static} StaticMethod() : string
+    + ExpressonBodiedMethod(x:int) : void
+}
+abstract class ClassB {
+    + {abstract} PropA : int <<get>> <<protected set>>
+    # <<virtual>> VirtualMethod() : string
+    + {abstract} AbstractMethod(arg1:int, arg2:double) : string
+}
+class ClassC <<sealed>> {
+    + <<override>> PropA : int <<get>> <<protected set>> = 100
+    +  <<event>> PropertyChanged : PropertyChangedEventHandler 
+    + <<override>> AbstractMethod(arg1:int, arg2:double) : string
+    # <<override>> VirtualMethod() : string
+}
+class Vector <<struct>> {
+    + X : double <<get>>
+    + Y : double <<get>>
+    + Z : double <<get>>
+    + Vector(x:double, y:double, z:double)
+    + Vector(source:Vector)
+}
+enum EnumA {
+    AA= 0x0001,
+    BB= 0x0002,
+    CC= 0x0004,
+    DD= 0x0008,
+    EE= 0x0010,
+}
+class NestedClass {
+    + A : int <<get>>
+}
+class "IList`1"<T> {
+}
+class InnerClass {
+    + X : string <<get>> = "xx"
+    + MethodX() : void
+}
+class InnerStruct <<struct>> {
+    + A : int <<get>>
+    + InnerStruct(a:int)
+}
+ClassB --> "publicA" ClassA
+ClassB o-> "listOfA<ClassA>" "IList`1"
+ClassB <|-- ClassC
+INotifyPropertyChanged <|-- ClassC
+ClassC --> "PropB" ClassB
+NestedClass --> "B" InnerClass
+NestedClass +-- InnerClass
+InnerClass +-- InnerStruct


### PR DESCRIPTION
Hi pierre3,
thanks for providing this amazing library.
I need some additions, one of it is this pull request, which provides the ability to ignore Properties without accessibility modifier.
I actually planned to implement it within the existing -ignore attribute, but discarded it.
For some examples see the included unit test.
I plan in some additional pull requests:

- add attribute to add "noters" to single attributes
- add attribute to add a class to a "collection". Via plantuml skins those classes/collections can then get equal background-colors
- add include_"collection".puml  to have the possibility to have "data-groups" / "data-categories".

Best wishes
Maik