### PR TITLE
Use .NET Standard 1.0 for Attributes project

### DIFF
--- a/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlAssociationAttribute.cs
+++ b/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlAssociationAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace PlantUmlClassDiagramGenerator.Attributes
+﻿using System;
+
+namespace PlantUmlClassDiagramGenerator.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public class PlantUmlAssociationAttribute : Attribute

--- a/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlClassDiagramGenerator.Attributes.csproj
+++ b/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlClassDiagramGenerator.Attributes.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+		<TargetFramework>netstandard1.0</TargetFramework>
 		<Description>
 This is an attribute classes liblary for the PlantUmlClassDiagramGenerator.
 https://www.nuget.org/packages/PlantUmlClassDiagramGenerator

--- a/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlDiagram.cs
+++ b/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlDiagram.cs
@@ -1,4 +1,6 @@
-﻿namespace PlantUmlClassDiagramGenerator.Attributes
+﻿using System;
+
+namespace PlantUmlClassDiagramGenerator.Attributes
 {
     [AttributeUsage(AttributeTargets.Class|AttributeTargets.Interface|AttributeTargets.Enum|AttributeTargets.Struct)]
     public class PlantUmlDiagramAttribute : Attribute

--- a/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlIgnoreAssociationAttribute.cs
+++ b/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlIgnoreAssociationAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace PlantUmlClassDiagramGenerator.Attributes
+﻿using System;
+
+namespace PlantUmlClassDiagramGenerator.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public class PlantUmlIgnoreAssociationAttribute : Attribute

--- a/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlIgnoreAttribute.cs
+++ b/src/PlantUmlClassDiagramgenerator.Attributes/PlantUmlIgnoreAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace PlantUmlClassDiagramGenerator.Attributes
+﻿using System;
+
+namespace PlantUmlClassDiagramGenerator.Attributes
 {
     [AttributeUsage(AttributeTargets.All)]
     public class PlantUmlIgnoreAttribute : Attribute


### PR DESCRIPTION
Currently, the Attributes project can only be referenced by .NET 6+ projects. This PR ensures maximum compatibility with legacy codebases.

[![Screenshot of .NET Standard compatibility chart](https://user-images.githubusercontent.com/20781397/219677438-9955c454-4fd2-4c1d-a62a-7ef11c6343cd.png)](https://dotnet.microsoft.com/en-us/platform/dotnet-standard)
