### PR TITLE
Bug fix: AttributeRequired not working in Directory based Generation

### DIFF
--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -182,7 +182,7 @@ namespace PlantUmlClassDiagramGenerator
                             "    ",
                             ignoreAcc,
                             parameters.ContainsKey("-createAssociation"),
-                            parameters.ContainsKey("-ignoreEmptyModifier"),
+                            parameters.ContainsKey("-attributeRequired"),
                             excludeUmlBeginEndTags);
                         gen.Generate(root);
                     }


### PR DESCRIPTION
Thanks for maintaining this useful tool! 

AttributeRequired flag does not work when input is directory instead of a file.

RootCause: Bug in Program.cs GeneratePlantUmlFromDir method where wrong flag name(ignoreEmptyModifier) is used. There is no reference to ignoreEmptyModifier in the whole repository except at this place. I presume it is orphan artefact which slipped in from local development.

Fix: Change -ignoreEmptyModifer to -attributeRequired similar to how GeneratePlantUmlFromFile handles it.