### PR TITLE
Extend exclude path to consider "**/" syntax (filtering on all folder levels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ puml-gen InputPath [OutputPath] [-dir] [-public | -ignore IgnoreAccessibilities]
 - -ignore: (Optional) Specify the accessibility of members to ignore, with a comma separated list.
 - -excludePaths: (Optional) Specify the exclude file and directory.   
   Specifies a relative path from the "InputPath", with a comma separated list.
+  To exclude multiple paths, which contain a specific folder name, preceed the name by "\*\*/". Example: "**/bin"
 - -createAssociation: (Optional) Create object associations from references of fields and properites.
 - -allInOne: (Optional) Only if -dir is set: copy the output of all diagrams to file include.puml (this allows a PlanUMLServer to render it).
 - -attributeRequired: (Optional) When this switch is enabled, only types with "PlantUmlDiagramAttribute" in the type declaration will be output.

--- a/src/PlantUmlClassDiagramGenerator/ExcludeFileFilter.cs
+++ b/src/PlantUmlClassDiagramGenerator/ExcludeFileFilter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlantUmlClassDiagramGenerator
+{
+    public class ExcludeFileFilter
+    {
+        public IEnumerable<string> GetFilesToProcess(IEnumerable<string> files, IList<string> excludePaths, string inputRoot)
+        {
+            return files.Where(f => !IsFileExcluded(f, excludePaths, inputRoot));
+        }
+
+        private static bool IsFileExcluded(string inputFile, IEnumerable<string> excludePaths, string inputRoot)
+        {
+            bool isExcluded = excludePaths
+                .Select(p => PathHelper.CombinePath(inputRoot, p))
+                .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase));
+
+            if (isExcluded)
+            {
+                Console.WriteLine($"Skipped \"{inputFile}\"...");
+            }
+
+            return isExcluded;
+        }
+    }
+}

--- a/src/PlantUmlClassDiagramGenerator/ExcludeFileFilter.cs
+++ b/src/PlantUmlClassDiagramGenerator/ExcludeFileFilter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace PlantUmlClassDiagramGenerator
@@ -13,9 +14,7 @@ namespace PlantUmlClassDiagramGenerator
 
         private static bool IsFileExcluded(string inputFile, IEnumerable<string> excludePaths, string inputRoot)
         {
-            bool isExcluded = excludePaths
-                .Select(p => PathHelper.CombinePath(inputRoot, p))
-                .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase));
+            bool isExcluded = excludePaths.Any(excludePath => IsFileExcluded(inputFile, excludePath, inputRoot));
 
             if (isExcluded)
             {
@@ -23,6 +22,19 @@ namespace PlantUmlClassDiagramGenerator
             }
 
             return isExcluded;
+        }
+
+        private static bool IsFileExcluded(string inputFile, string excludePath, string inputRoot)
+        {
+            if (excludePath.StartsWith("**/"))
+            {
+                return inputFile.Split('\\', '/').Any(x => x.StartsWith(excludePath[3..]));
+            }
+            else
+            {
+                string fullPath = PathHelper.CombinePath(inputRoot, excludePath);
+                return inputFile.StartsWith(fullPath, StringComparison.InvariantCultureIgnoreCase);
+            }
         }
     }
 }

--- a/src/PlantUmlClassDiagramGenerator/PathHelper.cs
+++ b/src/PlantUmlClassDiagramGenerator/PathHelper.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace PlantUmlClassDiagramGenerator
+{
+    public static class PathHelper
+    {
+        public static string CombinePath(string first, string second)
+        {
+            return first.TrimEnd(Path.DirectorySeparatorChar)
+                   + Path.DirectorySeparatorChar
+                   + second.TrimStart(Path.DirectorySeparatorChar);
+        }
+    }
+}

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -154,9 +154,7 @@ namespace PlantUmlClassDiagramGenerator
             var error = false;
             foreach (var inputFile in files)
             {
-                if (excludePaths
-                    .Select(p => CombinePath(inputRoot, p))
-                    .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase)))
+                if (IsFileExcluded(inputFile, excludePaths, inputRoot))
                 {
                     Console.WriteLine($"Skipped \"{inputFile}\"...");
                     continue;
@@ -220,6 +218,15 @@ namespace PlantUmlClassDiagramGenerator
                 return false;
             }
             return true;
+        }
+
+        private static bool IsFileExcluded(string inputFile, IList<string> excludePaths, string inputRoot)
+        {
+            bool isExcluded = excludePaths
+                .Select(p => CombinePath(inputRoot, p))
+                .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase));
+
+            return isExcluded;
         }
 
         private static Accessibilities GetIgnoreAccessibilities(Dictionary<string, string> parameters)

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -152,13 +152,9 @@ namespace PlantUmlClassDiagramGenerator
             if (!excludeUmlBeginEndTags) includeRefs.AppendLine("@startuml");
 
             var error = false;
-            foreach (var inputFile in files)
+            var filesToProcess = GetFilesToProcess(files, excludePaths, inputRoot);
+            foreach (var inputFile in filesToProcess)
             {
-                if (IsFileExcluded(inputFile, excludePaths, inputRoot))
-                {
-                    Console.WriteLine($"Skipped \"{inputFile}\"...");
-                    continue;
-                }
                 Console.WriteLine($"Processing \"{inputFile}\"...");
                 try
                 {
@@ -176,7 +172,7 @@ namespace PlantUmlClassDiagramGenerator
                         using var filestream = new FileStream(outputFile, FileMode.Create, FileAccess.Write);
                         using var writer = new StreamWriter(filestream);
                         var gen = new ClassDiagramGenerator(
-                            writer, 
+                            writer,
                             "    ",
                             ignoreAcc,
                             parameters.ContainsKey("-createAssociation"),
@@ -220,11 +216,21 @@ namespace PlantUmlClassDiagramGenerator
             return true;
         }
 
-        private static bool IsFileExcluded(string inputFile, IList<string> excludePaths, string inputRoot)
+        private static IEnumerable<string> GetFilesToProcess(IEnumerable<string> files, IList<string> excludePaths, string inputRoot)
+        {
+            return files.Where(f => !IsFileExcluded(f, excludePaths, inputRoot));
+        }
+
+        private static bool IsFileExcluded(string inputFile, IEnumerable<string> excludePaths, string inputRoot)
         {
             bool isExcluded = excludePaths
                 .Select(p => CombinePath(inputRoot, p))
                 .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase));
+
+            if (isExcluded)
+            {
+                Console.WriteLine($"Skipped \"{inputFile}\"...");
+            }
 
             return isExcluded;
         }

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -30,6 +30,8 @@ namespace PlantUmlClassDiagramGenerator
             ["-excludeUmlBeginEndTags"] = OptionType.Switch
         };
 
+        static readonly ExcludeFileFilter _excludeFileFilter = new ExcludeFileFilter();
+
         static int Main(string[] args)
         {
             Dictionary<string, string> parameters = MakeParameters(args);
@@ -152,7 +154,7 @@ namespace PlantUmlClassDiagramGenerator
             if (!excludeUmlBeginEndTags) includeRefs.AppendLine("@startuml");
 
             var error = false;
-            var filesToProcess = GetFilesToProcess(files, excludePaths, inputRoot);
+            var filesToProcess = _excludeFileFilter.GetFilesToProcess(files, excludePaths, inputRoot);
             foreach (var inputFile in filesToProcess)
             {
                 Console.WriteLine($"Processing \"{inputFile}\"...");
@@ -216,24 +218,6 @@ namespace PlantUmlClassDiagramGenerator
             return true;
         }
 
-        private static IEnumerable<string> GetFilesToProcess(IEnumerable<string> files, IList<string> excludePaths, string inputRoot)
-        {
-            return files.Where(f => !IsFileExcluded(f, excludePaths, inputRoot));
-        }
-
-        private static bool IsFileExcluded(string inputFile, IEnumerable<string> excludePaths, string inputRoot)
-        {
-            bool isExcluded = excludePaths
-                .Select(p => CombinePath(inputRoot, p))
-                .Any(p => inputFile.StartsWith(p, StringComparison.InvariantCultureIgnoreCase));
-
-            if (isExcluded)
-            {
-                Console.WriteLine($"Skipped \"{inputFile}\"...");
-            }
-
-            return isExcluded;
-        }
 
         private static Accessibilities GetIgnoreAccessibilities(Dictionary<string, string> parameters)
         {
@@ -296,9 +280,7 @@ namespace PlantUmlClassDiagramGenerator
 
         private static string CombinePath(string first, string second)
         {
-            return first.TrimEnd(Path.DirectorySeparatorChar)
-                + Path.DirectorySeparatorChar
-                + second.TrimStart(Path.DirectorySeparatorChar);
+            return PathHelper.CombinePath(first, second);
         }
     }
 }

--- a/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
+++ b/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\PlantUmlClassDiagramgenerator.Attributes\PlantUmlClassDiagramGenerator.Attributes.csproj" />
     <ProjectReference Include="..\..\src\PlantUmlClassDiagramGenerator.Library\PlantUmlClassDiagramGenerator.Library.csproj" />
+    <ProjectReference Include="..\..\src\PlantUmlClassDiagramGenerator\PlantUmlClassDiagramGenerator.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PlantUmlClassDiagramGeneratorTest/UnitTests/ExcludeFileFilterTest.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/UnitTests/ExcludeFileFilterTest.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PlantUmlClassDiagramGenerator;
+
+namespace PlantUmlClassDiagramGeneratorTest.UnitTests
+{
+    [TestClass]
+    public class ExcludeFileFilterTest
+    {
+        private ExcludeFileFilter testObject;
+
+        private const string InputRoot = "D:\\Development\\ProductA\\src";
+
+        private const string TestFile0 = "D:\\Development\\ProductA\\src\\ProjectA\\File1.cs";
+        private const string TestFile1 = "D:\\Development\\ProductA\\src\\ProjectA\\File2.cs";
+        private const string TestFile2 = "D:\\Development\\ProductA\\src\\ProjectA\\bin\\Domain.dll";
+        private const string TestFile3 = "D:\\Development\\ProductA\\src\\ProjectA\\obj\\Domain.dll";
+        private const string TestFile4 = "D:\\Development\\ProductA\\src\\ProjectB\\File1.cs";
+        private const string TestFile5 = "D:\\Development\\ProductA\\src\\ProjectB\\bin\\Domain.dll";
+        private const string TestFile6 = "D:\\Development\\ProductA\\src\\ProjectB\\obj\\Domain.dll";
+
+        private readonly string[] TestFiles =
+            {TestFile0, TestFile1, TestFile2, TestFile3, TestFile4, TestFile5, TestFile6};
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            testObject = new ExcludeFileFilter();
+        }
+
+        [DataTestMethod]
+        [DataRow(new string[] { }, new[] {0, 1, 2, 3, 4, 5, 6}, DisplayName = "Exclude path (empty array)")]
+        [DataRow(new[] {"ProjectA\\bin"}, new[] {0, 1, 3, 4, 5, 6}, DisplayName = "Exclude path (one)")]
+        [DataRow(new[] {"ProjectA\\bin", "ProjectB\\bin"}, new[] {0, 1, 3, 4, 6}, DisplayName = "Exclude path (multiple)")]
+        public void GetFilesToProcessTest(string[] excludePaths, int[] expectedTestFileIndices)
+        {
+            // Act
+            List<string> result = testObject.GetFilesToProcess(TestFiles, excludePaths, InputRoot).ToList();
+
+            // Assert
+            string[] expected = GetByIndices(TestFiles, expectedTestFileIndices);
+            CollectionAssert.AreEquivalent(expected, result);
+        }
+
+        private static string[] GetByIndices(string[] array, params int[] indices)
+        {
+            return indices.Select(i => array[i]).ToArray();
+        }
+    }
+}

--- a/test/PlantUmlClassDiagramGeneratorTest/UnitTests/ExcludeFileFilterTest.cs
+++ b/test/PlantUmlClassDiagramGeneratorTest/UnitTests/ExcludeFileFilterTest.cs
@@ -33,6 +33,9 @@ namespace PlantUmlClassDiagramGeneratorTest.UnitTests
         [DataRow(new string[] { }, new[] {0, 1, 2, 3, 4, 5, 6}, DisplayName = "Exclude path (empty array)")]
         [DataRow(new[] {"ProjectA\\bin"}, new[] {0, 1, 3, 4, 5, 6}, DisplayName = "Exclude path (one)")]
         [DataRow(new[] {"ProjectA\\bin", "ProjectB\\bin"}, new[] {0, 1, 3, 4, 6}, DisplayName = "Exclude path (multiple)")]
+        [DataRow(new[] {"**/bin"}, new[] {0, 1, 3, 4, 6}, DisplayName = "Exclude pattern (one)")]
+        [DataRow(new[] {"**/bin", "**/obj"}, new[] {0, 1, 4}, DisplayName = "Exclude pattern (multiple)")]
+        [DataRow(new[] {"**/bin", "ProjectB\\", "**/obj"}, new[] {0, 1}, DisplayName = "Mixed combination of exclude path and pattern")]
         public void GetFilesToProcessTest(string[] excludePaths, int[] expectedTestFileIndices)
         {
             // Act


### PR DESCRIPTION
With this change it is possible to apply the "exludePath" parameter to all directory levels. Example: "puml-gen -excludePaths **/obj" excludes all files where any of the (sub)directory names starts with "obj". The syntax is a subset of the filter options known by ".gitignore" files.

Related feature request: #66.