### PR TITLE
Suppress the compiler-generated members of record types in source generator.

### DIFF
--- a/src/PlantUmlClassDiagramGenerator.SourceGenerator/PlantUmlDiagramBuilder.cs
+++ b/src/PlantUmlClassDiagramGenerator.SourceGenerator/PlantUmlDiagramBuilder.cs
@@ -62,11 +62,16 @@ internal class PlantUmlDiagramBuilder(
                     }
                     break;
                 case IPropertySymbol propertySymbol:
-                    SetPropertyDeclaration(propertySymbol);
-                    SetPropertyAssociation(propertySymbol, symbols);
+                    // Skip compiler-generated properties.
+                    if (!propertySymbol.IsImplicitlyDeclared)
+                    {
+                        SetPropertyDeclaration(propertySymbol);
+                        SetPropertyAssociation(propertySymbol, symbols);
+                    }
                     break;
                 case IMethodSymbol methodSymbol:
-                    if (methodSymbol.MethodKind is not MethodKind.PropertyGet
+                    if (!methodSymbol.IsSoleRecordConstructor() // Only include constructor when there is more than one.
+                        && methodSymbol.MethodKind is not MethodKind.PropertyGet
                         and not MethodKind.PropertySet
                         and not MethodKind.EventAdd
                         and not MethodKind.EventRemove

--- a/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/Item.puml
+++ b/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/Item.puml
@@ -1,17 +1,6 @@
 @startuml Item
 class Item <<record>>  {
-    + Item(Name : string, Value : double)
-    # <<readonly>> <<virtual>> EqualityContract : Type <<get>>
     + Name : string <<get>> <<set>>
     + Value : double <<get>> <<set>>
-    + <<override>> ToString() : string
-    # <<virtual>> PrintMembers(builder : StringBuilder) : bool
-    + {static} operator !=(left : Item?, right : Item?) : bool
-    + {static} operator ==(left : Item?, right : Item?) : bool
-    + <<override>> GetHashCode() : int
-    + <<override>> Equals(obj : object?) : bool
-    + <<virtual>> Equals(other : Item?) : bool
-    # Item(original : Item)
-    + Deconstruct(Name : string, Value : double) : void
 }
 @enduml

--- a/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/Parameters.puml
+++ b/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/Parameters.puml
@@ -1,18 +1,7 @@
 @startuml Parameters
 class Parameters <<record>>  {
-    # <<readonly>> <<virtual>> EqualityContract : Type <<get>>
     + <<readonly>> X : int <<get>>
     + <<readonly>> Y : int <<get>>
-    + Parameters(x : int, y : int)
-    + Area() : int
-    + <<override>> ToString() : string
-    # <<virtual>> PrintMembers(builder : StringBuilder) : bool
-    + {static} operator !=(left : Parameters?, right : Parameters?) : bool
-    + {static} operator ==(left : Parameters?, right : Parameters?) : bool
-    + <<override>> GetHashCode() : int
-    + <<override>> Equals(obj : object?) : bool
-    + <<virtual>> Equals(other : Parameters?) : bool
-    # Parameters(original : Parameters)
 }
 "IEquatable`1" "<Parameters>" <|.. Parameters
 @enduml

--- a/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/RecordA.puml
+++ b/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/RecordA.puml
@@ -1,17 +1,6 @@
 @startuml RecordA
 class RecordA <<record>>  {
-    + RecordA(Name : string, Value : int)
-    # <<readonly>> <<virtual>> EqualityContract : Type <<get>>
     + Name : string <<get>> <<set>>
     + Value : int <<get>> <<set>>
-    + <<override>> ToString() : string
-    # <<virtual>> PrintMembers(builder : StringBuilder) : bool
-    + {static} operator !=(left : RecordA?, right : RecordA?) : bool
-    + {static} operator ==(left : RecordA?, right : RecordA?) : bool
-    + <<override>> GetHashCode() : int
-    + <<override>> Equals(obj : object?) : bool
-    + <<virtual>> Equals(other : RecordA?) : bool
-    # RecordA(original : RecordA)
-    + Deconstruct(Name : string, Value : int) : void
 }
 @enduml

--- a/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/RecordStruct.puml
+++ b/test/generated-uml/SourceGeneratorTest.Library/SourceGeneratorTest/Library/Types/RecordStruct.puml
@@ -1,17 +1,7 @@
 @startuml RecordStruct
 struct RecordStruct <<sealed>> <<record>>  {
-    + RecordStruct(X : float, Y : float, Z : float)
     + X : float <<get>> <<set>>
     + Y : float <<get>> <<set>>
     + Z : float <<get>> <<set>>
-    + <<readonly>> <<override>> ToString() : string
-    - <<readonly>> PrintMembers(builder : StringBuilder) : bool
-    + {static} operator !=(left : RecordStruct, right : RecordStruct) : bool
-    + {static} operator ==(left : RecordStruct, right : RecordStruct) : bool
-    + <<readonly>> <<override>> GetHashCode() : int
-    + <<readonly>> <<override>> Equals(obj : object) : bool
-    + <<readonly>> Equals(other : RecordStruct) : bool
-    + <<readonly>> Deconstruct(X : float, Y : float, Z : float) : void
-    + RecordStruct()
 }
 @enduml


### PR DESCRIPTION
This resolves #108 by updating the source generator to not include the compiler-generated methods of a record type. It also omits the constructor that includes every property as arguments, but only if there are no other constructors. For me, this results in more useful diagrams for showing the design of a project.