### PR TITLE
Add System.CommandLine CLI and multi-directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,35 +40,35 @@ dotnet tool install --global PlantUmlClassDiagramGenerator
 Run the "puml-gen" command.
 
 ```bat
-puml-gen InputPath [OutputPath] [-dir] [-addPackageTags] [-public | -ignore IgnoreAccessibilities] [-excludePaths ExcludePathList] [-createAssociation]
+puml-gen <input> [output] [--dir] [--add-package-tags] [--public | --ignore <accessibilities>] [--exclude-paths <paths>] [--create-association]
 ```
 
-- InputPath: (Required) Sets a input source file or directory name.
-- OutputPath: (Optional) Sets a output file or directory name.  
+- input: (Required) Sets a input source file or directory name.
+- output: (Optional) Sets a output file or directory name.  
   If you omit this option, plantuml files are outputted to same directory as the input files.
-- -dir: (Optional) Specify when InputPath and OutputPath are directory names.
-- -addPackageTags: (Optional) If there is "-dir" tag, then program adds "package" tags and puts all relations in the end of include.puml
-- -public: (Optional) If specified, only public accessibility members are output. 
-- -ignore: (Optional) Specify the accessibility of members to ignore, with a comma separated list.
-- -excludePaths: (Optional) Specify the exclude file and directory.   
-  Specifies a relative path from the "InputPath", with a comma separated list.
+- --dir, -d: (Optional) Specify when input and output are directory names.
+- --add-package-tags: (Optional) If --dir is set, adds "package" tags and puts all relations in the end of include.puml
+- --public, -p: (Optional) If specified, only public accessibility members are output. 
+- --ignore, -i: (Optional) Specify the accessibility of members to ignore, with a comma separated list.
+- --exclude-paths, -e: (Optional) Specify the exclude file and directory.   
+  Specifies a relative path from the input, with a comma separated list.
   To exclude multiple paths, which contain a specific folder name, preceed the name by "\*\*/". Example: "**/bin"
-- -createAssociation: (Optional) Create object associations from references of fields and properites.
-- -allInOne: (Optional) Only if -dir is set: copy the output of all diagrams to file include.puml (this allows a PlanUMLServer to render it).
-- -attributeRequired: (Optional) When this switch is enabled, only types with "PlantUmlDiagramAttribute" in the type declaration will be output.
-- -excludeUmlBeginEndTags: (Optional) When this switch is enabled, it will exclude the \"@startuml\" and \"@enduml\" tags from the puml file.
+- --create-association, -a: (Optional) Create object associations from references of fields and properites.
+- --all-in-one: (Optional) Only if --dir is set: copy the output of all diagrams to file include.puml (this allows a PlanUMLServer to render it).
+- --attribute-required: (Optional) When this switch is enabled, only types with "PlantUmlDiagramAttribute" in the type declaration will be output.
+- --exclude-uml-tags: (Optional) When this switch is enabled, it will exclude the \"@startuml\" and \"@enduml\" tags from the puml file.
 
 examples
 ```bat
-puml-gen C:\Source\App1\ClassA.cs -public
+puml-gen C:\Source\App1\ClassA.cs --public
 ```
 
 ```bat
-puml-gen C:\Source\App1 C:\PlantUml\App1 -dir -ignore Private,Protected -createAssociation -allInOne
+puml-gen C:\Source\App1 C:\PlantUml\App1 --dir --ignore Private,Protected --create-association --all-in-one
 ```
 
 ```bat
-puml-gen C:\Source\App1 C:\PlantUml\App1 -dir -excludePaths bin,obj,Properties
+puml-gen C:\Source\App1 C:\PlantUml\App1 --dir --exclude-paths bin,obj,Properties
 ```
 
 ## Specification for conversion to PlantUML
@@ -467,7 +467,7 @@ You can add the package [PlantUmlClassDiagramGenerator.Attributes](https://www.n
 
 ### PlantUmlDiagramAttribute
 Only types to which PlantUmlDiagramAttribute has been added will be output.
-This attribute is enabled if the -attributeRequired switch is added to the command line argument.
+This attribute is enabled if the --attribute-required switch is added to the command line argument.
 
 This attribute can be added only to type declalerations.
 - class

--- a/src/PlantUmlClassDiagramGenerator/Generator/PlantUmlFromMultiDirGenerator.cs
+++ b/src/PlantUmlClassDiagramGenerator/Generator/PlantUmlFromMultiDirGenerator.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using PlantUmlClassDiagramGenerator.Library;
+using PlantUmlClassDiagramGenerator.Library.ClassDiagramGenerator;
+
+namespace PlantUmlClassDiagramGenerator.Generator;
+
+/// <summary>
+/// Processes multiple source directories into a single PlantUML diagram.
+/// Input format for "in" parameter: "Label=Path;Label=Path;..."
+/// Each directory becomes a package block in the output.
+/// </summary>
+public class PlantUmlFromMultiDirGenerator : IPlantUmlGenerator
+{
+    public bool GeneratePlantUml(Dictionary<string, string> parameters)
+    {
+        var inputSpec = parameters["in"];
+        var entries = ParseEntries(inputSpec);
+
+        if (entries.Count == 0)
+        {
+            Console.WriteLine("No valid directory entries found.");
+            return false;
+        }
+
+        foreach (var (label, path) in entries)
+        {
+            if (!Directory.Exists(path))
+            {
+                Console.WriteLine($"Directory \"{path}\" (label \"{label}\") does not exist.");
+                return false;
+            }
+        }
+
+        if (!parameters.TryGetValue("out", out string outputFile))
+        {
+            Console.WriteLine("Output file path required for multi-dir mode.");
+            return false;
+        }
+
+        try
+        {
+            var outdir = Path.GetDirectoryName(outputFile);
+            if (!string.IsNullOrEmpty(outdir))
+                Directory.CreateDirectory(outdir);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return false;
+        }
+
+        var excludePaths = new List<string>();
+        if (parameters.TryGetValue("-excludePaths", out string excludePathValue))
+        {
+            var splitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+            excludePaths.AddRange(excludePathValue.Split(',', splitOptions));
+        }
+
+        Accessibilities ignoreAcc = IPlantUmlGenerator.GetIgnoreAccessibilities(parameters);
+        bool createAssociation = parameters.ContainsKey("-createAssociation");
+        bool attributeRequired = parameters.ContainsKey("-attributeRequired");
+
+        var output = new StringBuilder();
+        output.AppendLine("@startuml");
+        output.AppendLine();
+
+        RelationshipCollection allRelationships = new();
+        var error = false;
+
+        foreach (var (label, inputRoot) in entries)
+        {
+            output.AppendLine($"package \"{label}\" {{");
+
+            var pumlexclude = PathHelper.CombinePath(inputRoot, ".pumlexclude");
+            var dirExcludes = new List<string>(excludePaths);
+            if (File.Exists(pumlexclude))
+            {
+                dirExcludes.AddRange(
+                    File.ReadAllLines(pumlexclude)
+                        .Where(p => !string.IsNullOrWhiteSpace(p))
+                        .Select(p => p.Trim()));
+            }
+
+            var files = Directory.EnumerateFiles(inputRoot, "*.cs", SearchOption.AllDirectories);
+            var filesToProcess = ExcludeFileFilter.GetFilesToProcess(files, dirExcludes, inputRoot);
+
+            foreach (var inputFile in filesToProcess)
+            {
+                Console.WriteLine($"Processing \"{inputFile}\"...");
+                try
+                {
+                    using var stream = new FileStream(inputFile, FileMode.Open, FileAccess.Read);
+                    var tree = CSharpSyntaxTree.ParseText(SourceText.From(stream));
+                    var root = tree.GetRoot();
+
+                    using var sw = new StringWriter();
+                    var gen = new ClassDiagramGenerator(
+                        sw, "    ", ignoreAcc, createAssociation, attributeRequired,
+                        excludeUmlBeginEndTags: true, addPackageTags: false);
+                    gen.Generate(root);
+                    allRelationships.AddAll(gen.relationships);
+
+                    foreach (var line in sw.ToString().Split('\n'))
+                    {
+                        var trimmed = line.TrimEnd('\r');
+                        if (!string.IsNullOrWhiteSpace(trimmed))
+                            output.AppendLine("    " + trimmed);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    error = true;
+                }
+            }
+
+            output.AppendLine("}");
+            output.AppendLine();
+        }
+
+        var relLines = ClassDiagramGenerator.GenerateRelationships(allRelationships);
+        foreach (var line in relLines.Distinct())
+        {
+            output.AppendLine(line);
+        }
+
+        output.AppendLine("@enduml");
+
+        File.WriteAllText(outputFile, output.ToString());
+        Console.WriteLine($"Written to \"{outputFile}\"");
+
+        if (error)
+        {
+            Console.WriteLine("There were files that could not be processed.");
+            return false;
+        }
+        return true;
+    }
+
+    private static List<(string Label, string Path)> ParseEntries(string spec)
+    {
+        var result = new List<(string, string)>();
+        var splitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+        var segments = spec.Split(';', splitOptions);
+
+        foreach (var segment in segments)
+        {
+            var eqIndex = segment.IndexOf('=');
+            if (eqIndex > 0)
+            {
+                var label = segment[..eqIndex].Trim();
+                var path = segment[(eqIndex + 1)..].Trim();
+                result.Add((label, Path.GetFullPath(path)));
+            }
+            else
+            {
+                var path = Path.GetFullPath(segment);
+                var label = new DirectoryInfo(path).Name;
+                result.Add((label, path));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/PlantUmlClassDiagramGenerator/PlantUmlClassDiagramGenerator.csproj
+++ b/src/PlantUmlClassDiagramGenerator/PlantUmlClassDiagramGenerator.csproj
@@ -12,20 +12,21 @@
 		<RepositoryType></RepositoryType>
 		<PackageTags>plantuml</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.4.0</Version>
+		<Version>1.5.0</Version>
 		<Authors>pierre3</Authors>
 		<Company />
 		<Product />
 		<PackageReleaseNotes>
-			[V1.4.0]
-			- Updated the target framework to .NET 8.0.
-			- Fixed an issue where Nullable types were not being output with the createAssociation option.
+			[V1.5.0]
+			- Replaced hand-rolled argument parser with System.CommandLine for proper --help, --version, and flag handling.
+			- Added multi-directory mode (Label=Path;Label=Path;...) for combined package diagrams.
 		</PackageReleaseNotes>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\PlantUmlClassDiagramGenerator.Library\PlantUmlClassDiagramGenerator.Library.csproj" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-*" />
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -1,92 +1,143 @@
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using PlantUmlClassDiagramGenerator.Library;
-using System.Runtime.InteropServices;
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using PlantUmlClassDiagramGenerator.Generator;
-using PlantUmlClassDiagramGenerator.Library.ClassDiagramGenerator;
 
 namespace PlantUmlClassDiagramGenerator;
 
 class Program
 {
-    private static IPlantUmlGenerator generator;
-
-    enum OptionType
-    {
-        Value,
-        Switch
-    }
-
-    static readonly Dictionary<string, OptionType> options = new()
-    {
-        ["-dir"] = OptionType.Switch,
-        ["-public"] = OptionType.Switch,
-        ["-ignore"] = OptionType.Value,
-        ["-excludePaths"] = OptionType.Value,
-        ["-createAssociation"] = OptionType.Switch,
-        ["-allInOne"] = OptionType.Switch,
-        ["-attributeRequired"] = OptionType.Switch,
-        ["-excludeUmlBeginEndTags"] = OptionType.Switch,
-        ["-addPackageTags"] = OptionType.Switch
-    };
-
     static int Main(string[] args)
     {
-        Dictionary<string, string> parameters = MakeParameters(args);
-        if (!parameters.ContainsKey("in"))
+        var inputArg = new Argument<string>("input")
         {
-            Console.WriteLine("Specify a source file name or directory name.");
-            return -1;
-        }
+            Description = "Source file path, directory path, or multi-dir spec (Label=Path;Label=Path;...)"
+        };
 
-        if (parameters.ContainsKey("-dir"))
-            generator = new PlantUmlFromDirGenerator();
-        else
-            generator = new PlantUmlFromFileGenerator();
-
-        return !generator.GeneratePlantUml(parameters) ? 1 : 0;
-    }
-
-
-    private static Dictionary<string, string> MakeParameters(string[] args)
-    {
-        var currentKey = "";
-        var parameters = new Dictionary<string, string>();
-
-        foreach (var arg in args)
+        var outputArg = new Argument<string>("output")
         {
-            if (currentKey != string.Empty)
-            {
-                parameters.Add(currentKey, arg);
-                currentKey = "";
-                continue;
-            }
+            Description = "Output file or directory path",
+            DefaultValueFactory = _ => null!
+        };
 
-            if (options.TryGetValue(arg, out OptionType value))
+        var dirOption = new Option<bool>("--dir", "-d")
+        {
+            Description = "Process input as a directory of .cs files"
+        };
+
+        var publicOption = new Option<bool>("--public", "-p")
+        {
+            Description = "Only include public members"
+        };
+
+        var ignoreOption = new Option<string>("--ignore", "-i")
+        {
+            Description = "Comma-separated accessibilities to ignore (e.g. Private,Internal)"
+        };
+
+        var excludePathsOption = new Option<string>("--exclude-paths", "-e")
+        {
+            Description = "Comma-separated paths to exclude from processing"
+        };
+
+        var createAssociationOption = new Option<bool>("--create-association", "-a")
+        {
+            Description = "Generate association lines between types"
+        };
+
+        var allInOneOption = new Option<bool>("--all-in-one")
+        {
+            Description = "Combine all output into a single file (directory mode)"
+        };
+
+        var attributeRequiredOption = new Option<bool>("--attribute-required")
+        {
+            Description = "Only process types with [PlantUmlDiagram] attribute"
+        };
+
+        var excludeUmlTagsOption = new Option<bool>("--exclude-uml-tags")
+        {
+            Description = "Exclude @startuml/@enduml tags from output"
+        };
+
+        var addPackageTagsOption = new Option<bool>("--add-package-tags")
+        {
+            Description = "Add package tags for namespaces"
+        };
+
+        var rootCommand = new RootCommand("Generate PlantUML class diagrams from C# source code")
+        {
+            Arguments = { inputArg, outputArg },
+            Options =
             {
-                if (value == OptionType.Value)
-                {
-                    currentKey = arg;
-                }
-                else
-                {
-                    parameters.Add(arg, string.Empty);
-                }
+                dirOption,
+                publicOption,
+                ignoreOption,
+                excludePathsOption,
+                createAssociationOption,
+                allInOneOption,
+                attributeRequiredOption,
+                excludeUmlTagsOption,
+                addPackageTagsOption
             }
+        };
+
+        rootCommand.SetAction(parseResult =>
+        {
+            var input = parseResult.GetValue(inputArg)!;
+            var output = parseResult.GetValue(outputArg);
+
+            var parameters = new Dictionary<string, string> { ["in"] = input };
+            if (!string.IsNullOrEmpty(output)) parameters["out"] = output;
+            if (parseResult.GetValue(dirOption)) parameters["-dir"] = string.Empty;
+            if (parseResult.GetValue(publicOption)) parameters["-public"] = string.Empty;
+            if (parseResult.GetValue(ignoreOption) is { } ignore) parameters["-ignore"] = ignore;
+            if (parseResult.GetValue(excludePathsOption) is { } exclude) parameters["-excludePaths"] = exclude;
+            if (parseResult.GetValue(createAssociationOption)) parameters["-createAssociation"] = string.Empty;
+            if (parseResult.GetValue(allInOneOption)) parameters["-allInOne"] = string.Empty;
+            if (parseResult.GetValue(attributeRequiredOption)) parameters["-attributeRequired"] = string.Empty;
+            if (parseResult.GetValue(excludeUmlTagsOption)) parameters["-excludeUmlBeginEndTags"] = string.Empty;
+            if (parseResult.GetValue(addPackageTagsOption)) parameters["-addPackageTags"] = string.Empty;
+
+            IPlantUmlGenerator generator;
+            if (input.Contains(';'))
+                generator = new PlantUmlFromMultiDirGenerator();
+            else if (parameters.ContainsKey("-dir"))
+                generator = new PlantUmlFromDirGenerator();
             else
+                generator = new PlantUmlFromFileGenerator();
+
+            return generator.GeneratePlantUml(parameters) ? 0 : 1;
+        });
+
+        for (int i = 0; i < rootCommand.Options.Count; i++)
+        {
+            if (rootCommand.Options[i] is HelpOption helpOption)
             {
-                if (!parameters.TryAdd("in", arg))
-                {
-                    parameters.TryAdd("out", arg);
-                }
+                helpOption.Action = new HelpWithExamplesAction((HelpAction)helpOption.Action!);
+                break;
             }
         }
 
-        return parameters;
+        var parseResult = rootCommand.Parse(args);
+        return parseResult.Invoke();
+    }
+}
+
+sealed class HelpWithExamplesAction(HelpAction inner) : SynchronousCommandLineAction
+{
+    public override int Invoke(ParseResult parseResult)
+    {
+        inner.Invoke(parseResult);
+
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  puml-gen C:\\Source\\App1\\ClassA.cs --public");
+        Console.WriteLine("  puml-gen C:\\Source\\App1 C:\\PlantUml\\App1 --dir --ignore Private,Protected --create-association --all-in-one");
+        Console.WriteLine("  puml-gen C:\\Source\\App1 C:\\PlantUml\\App1 --dir --exclude-paths bin,obj,Properties");
+
+        return 0;
     }
 }


### PR DESCRIPTION
Replace hand-rolled argument parser with System.CommandLine for modern --help, --version, and double-dash and short aliases.

Add multi-directory mode (Label=Path;Label=Path;...) that generates a single combined diagram with package blocks per directory.

- Bump version to 1.5.0
- Update README with new flag syntax and examples